### PR TITLE
Added a fix for an intermittent IE issue

### DIFF
--- a/item.js
+++ b/item.js
@@ -164,6 +164,10 @@ Item.prototype.getPosition = function() {
 
 // set settled position, apply padding
 Item.prototype.layoutPosition = function() {
+  if ( !this.layout.size ) {
+    this.layout.getSize()
+  }
+  
   var layoutSize = this.layout.size;
   var layoutOptions = this.layout.options;
   var style = {};


### PR DESCRIPTION
Internet Explorer 10 (on Windows 7 inside a VM) would sometimes report that `this.layout.size` was null or undefined when running `layoutPosition()` for the first item in my Masonry layout.  I could never discern any pattern as to when IE decided to issue the error and when it didn't, leads me to think there may be a race condition somewhere in Outlayer.  Being more intimately familiar with Outlayer's inner workings, you probably have a better idea of what's going on than I do.  At any rate, this fix appears to have corrected the issue for me, and I wanted to share it.