### PR TITLE
Only unbind resize event if it was bound before.

### DIFF
--- a/outlayer.js
+++ b/outlayer.js
@@ -648,7 +648,9 @@ Outlayer.prototype.bindResize = function() {
  * Unbind layout to window resizing
  */
 Outlayer.prototype.unbindResize = function() {
-  eventie.unbind( window, 'resize', this );
+  if ( this.isResizeBound ) {
+    eventie.unbind( window, 'resize', this );
+  }
   this.isResizeBound = false;
 };
 


### PR DESCRIPTION
In case options.isResizeBound is false and no resize handling should be done `destroy` event fail in IE8 due to not being able to detach event.
