### PR TITLE
Signed-off-by: Matt Harker <thundercloud@theflux.co.uk>

### DIFF
--- a/outlayer.js
+++ b/outlayer.js
@@ -869,6 +869,8 @@ Outlayer.prototype.destroy = function() {
 
   this.unbindResize();
 
+  var id = this.element.outlayerGUID;
+  delete this.instances[ id ]; // remove reference to instance by id
   delete this.element.outlayerGUID;
   // remove data for jQuery
   if ( jQuery ) {


### PR DESCRIPTION
It seems that Outlayer maintains an internal list of instances created, referenced by the element's outlayerGUID, but those references aren't removed when the outlayer instance is destroyed. 

Because of this, and the outlayer's track of the element that an instance was created on, these elements are never able to be garbage collected, which, over time in single page apps, will massively inflate the heap size of the page.

This pull request contains a small fix to clear the outlayer instance from the instances object on destruction.
