### PR TITLE
[Fix] instances is not a member of Outlayer

### DIFF
--- a/outlayer.js
+++ b/outlayer.js
@@ -870,7 +870,7 @@ Outlayer.prototype.destroy = function() {
   this.unbindResize();
 
   var id = this.element.outlayerGUID;
-  delete this.instances[ id ]; // remove reference to instance by id
+  delete instances[ id ]; // remove reference to instance by id
   delete this.element.outlayerGUID;
   // remove data for jQuery
   if ( jQuery ) {


### PR DESCRIPTION
Based on a response from @maimairel, it becomes apparent that my previous fix for this issue was transcribed incorrectly from the place I initially made the fix.

This corrects that oversight.
