### PR TITLE
Add `_getItemIndexToLayOut` to allow subclasses to pick the next element...

### DIFF
--- a/outlayer.js
+++ b/outlayer.js
@@ -374,9 +374,19 @@ Outlayer.prototype._layoutItems = function( items, isInstant ) {
   this._itemsOn( items, 'layout', onItemsLayout );
 
   var queue = [];
+  var _items = items.slice(0);
 
-  for ( var i=0, len = items.length; i < len; i++ ) {
-    var item = items[i];
+  while (_items.length > 0)
+  {
+    var idx = this._getItemIndexToLayOut(_items);
+    
+    if (!idx && (idx !== 0))
+    {
+        break;
+    }
+    
+    var item = _items.splice(idx, 1)[0];
+    
     // get x/y object from method
     var position = this._getItemLayoutPosition( item );
     // enqueue
@@ -386,6 +396,15 @@ Outlayer.prototype._layoutItems = function( items, isInstant ) {
   }
 
   this._processLayoutQueue( queue );
+};
+
+/**
+ * get item to lay out in the current iteration.
+ * @param {Array} items
+ * @returns {Number} Index into items of the item to lay out
+ */
+Outlayer.prototype._getItemIndexToLayOut = function ( items ) {
+  return 0;
 };
 
 /**


### PR DESCRIPTION
... to lay out by themselves.

This allows masonry or similar plugins to implement a custom "element picking" strategy, where they can decide if they want to use an element further into the array of items instead of the default "next" element.

The default behavior is the same as previous versions and should be backwards compatible. As we create a local copy of items that acts as a queue, there might be a slight overhead compared with a single assignment.