### PR TITLE
Set ontransitionend handler on all properties that will transition when an item is hidden.

### DIFF
--- a/item.js
+++ b/item.js
@@ -467,20 +467,23 @@ Item.prototype.hide = function() {
   this.css({ display: '' });
 
   var options = this.layout.options;
+
+  var propTransitionEnds = {};
+  for (var prop in options.hiddenStyle) {
+    propTransitionEnds[prop] = function() {
+      // check if still hidden
+      // during transition, item may have been un-hidden
+      if ( this.isHidden ) {
+        this.css({ display: 'none' });
+      }
+    };
+  }
   this.transition({
     from: options.visibleStyle,
     to: options.hiddenStyle,
     // keep hidden stuff hidden
     isCleaning: true,
-    onTransitionEnd: {
-      opacity: function() {
-        // check if still hidden
-        // during transition, item may have been un-hidden
-        if ( this.isHidden ) {
-          this.css({ display: 'none' });
-        }
-      }
-    }
+    onTransitionEnd: propTransitionEnds
   });
 };
 

--- a/test/hide-without-opacity.js
+++ b/test/hide-without-opacity.js
@@ -1,0 +1,27 @@
+( function() {
+
+
+test( 'hide-without-opacity', function() {
+
+  var container = document.querySelector('#hide-item-without-opacity');
+  var layout = new Outlayer( container, {
+    itemSelector: '.item',
+    transitionDuration: '0.001s',
+    hiddenStyle: {
+      transform: 'translateY(200px)'
+    },
+    visibleStyle: {
+      transform: 'transformY(0)'
+    }
+  });
+  var item = layout.getItem( container.querySelector( '.item' ) );
+  stop();
+  item.hide();
+  setTimeout(function() {
+    equal( container.querySelector( '.item' ).style.display, "none" );
+    start();
+  }, 150);
+
+});
+
+})();

--- a/test/index.html
+++ b/test/index.html
@@ -44,6 +44,7 @@
   <script src="destroy.js"></script>
   <script src="declarative.js"></script>
   <script src="jquery-plugin.js"></script>
+  <script src="hide-without-opacity.js"></script>
 
 </head>
 <body>
@@ -244,6 +245,12 @@
     <div class="item"></div>
     <div class="item"></div>
     <div class="item"></div>
+    <div class="item"></div>
+  </div>
+
+  <h2>Hide without opacity</h2>
+
+  <div id="hide-item-without-opacity">
     <div class="item"></div>
   </div>
 


### PR DESCRIPTION
That the `hiddenStyle` option needs a declaration that actually hides the card is more obvious in hindsight, but it was unexpected to me that overriding `hiddenStyle` led to the items remaining visible after they were filtered by the `isotope.filter` call.

This change was an approach that fixes that behavior, and seemed to have minimal impact. It is suboptimal that the handler would execute for any properties in `hiddenStyle`.

The unexpected nature could be solved by a note in documentation.

I could also see removing the `onTransitionEnd` handler in `Item.hide`, and leave the hiding of the item up to the `hiddenStyle` option completely. Part of the confusion is that the items are hidden without any overrides to `hiddenStyle`. As default behavior, this should occur unless a specific request to prevent the hiding after the transition is done is made.
