### PR TITLE
adding item.js to bower.json 'main'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,10 @@
   "name": "outlayer",
   "version": "1.4.0",
   "description": "the brains and guts of a layout library",
-  "main": "outlayer.js",
+  "main": [
+    "item.js",
+    "outlayer.js"
+  ],
   "dependencies": {
     "doc-ready": "1.0.x",
     "eventEmitter": ">=4.2 <5",


### PR DESCRIPTION
some tasks runner (e.g. brunch) use 'main' to find the files to use:
if item.js isn't in 'main' it will be ignored