### PR TITLE
Composer bower asset plugin comp.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "main": "outlayer.js",
   "dependencies": {
     "doc-ready": "1.0.x",
-    "eventEmitter": ">=4.2 <5",
+    "eventEmitter": ">=4.2.0 <5",
     "eventie": "~1.0.3",
     "get-size": "~1.2.2",
     "get-style-property": "~1.0.4",


### PR DESCRIPTION
I get the error below when installing the another package.
```
  Problem 1
    - bower-asset/outlayer v1.4.0 requires bower-asset/eventemitter >=4.2,<5 -> no matching package found.
    - bower-asset/outlayer v1.4.1 requires bower-asset/eventemitter >=4.2,<5 -> no matching package found.
    - bower-asset/masonry v3.3.1 requires bower-asset/outlayer >=1.4.0,<1.5 -> satisfiable by bower-asset/outlayer[v1.4.1, v1.4.0].
    - Installation request for bower-asset/masonry 3.3.1 -> satisfiable by bower-asset/masonry[v3.3.1].
```
Probably plugin cannot understand since there isn't the third number.