### PR TITLE
Point to correct EventEmitter package on bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "main": "outlayer.js",
   "dependencies": {
     "doc-ready": "1.0.x",
-    "eventEmitter": ">=4.2 <5",
+    "EventEmitter.js": ">=4.2 <5",
     "eventie": "~1.0.3",
     "get-size": "~1.2.2",
     "get-style-property": "~1.0.4",


### PR DESCRIPTION
in the package.json the EventEmitter used is "wolfy87-eventemitter": ">=4.2 <5",
on bower this package seems to be called "EventEmitter.js" not "EventEmitter"