### PR TITLE
Broken testcase

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -189,13 +189,14 @@
     <div class="item"></div>
   </div>
 
+<div style="position:absolute; left:300px; top:600px">
   <h2>_getElementOffset</h2>
 
   <div id="offset" class="container">
     <div class="stamp stamp1"></div>
     <div class="stamp stamp2"></div>
   </div>
-
+</div>
   <!-- <h2>item onTransitionEnd</h2>
 
   <div id="item-on-transition-end" class="container">


### PR DESCRIPTION
'_getElementOffset' testcase is broken!

The more you add tesecase, offset value is broken.

So, I changed this position of '_getElementOffset' div from 'static' to `absolute'
in order to work regardless of a number of tesecases