### PR TITLE
Switch Vendor prefixes to Object

### DIFF
--- a/item.js
+++ b/item.js
@@ -61,12 +61,12 @@ var transitionEndEvent = {
 }[ transitionProperty ];
 
 // cache all vendor properties
-var vendorProperties = [
-  transformProperty,
-  transitionProperty,
-  transitionProperty + 'Duration',
-  transitionProperty + 'Property'
-];
+var vendorProperties = {
+  transform: transformProperty,
+  transition: transitionProperty,
+  transitionDuration: transitionProperty + 'Duration',
+  transitionPropety: transitionProperty + 'Property'
+}
 
 // -------------------------- Item -------------------------- //
 


### PR DESCRIPTION
I just recently ran into an issue while testing the Masonry plugin on Safari 8 (both on Desktop and on my IPad). The items were not transitioning at all, and that was also messing up the layout.

Reason for this I found is that the `proto.css` method was trying to apply the `transform` property, while this browser required `webkitTransform`. By changing the `vendorProperties` variable to an object,  the css method can reference the prefixed properties by accessing them by their non-prefixed name.

This change fixed Masonry for me.