### PR TITLE
Fixed bower.json issue.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,10 @@
 {
   "name": "outlayer",
   "description": "the brains and guts of a layout library",
-  "main": "outlayer.js",
+  "main": [
+    "item.js",
+    "outlayer.js"
+  ],
   "dependencies": {
     "ev-emitter": "~1.0.0",
     "get-size": "~2.0.2",


### PR DESCRIPTION
outlayer.js references the 'Item' class. Updated bower.json to include item.js to fix broken bower installs.