### PR TITLE
fix bug with scrolling when there is infinity scroll

### DIFF
--- a/item.js
+++ b/item.js
@@ -94,10 +94,6 @@ proto._create = function() {
     clean: {},
     onEnd: {}
   };
-
-  this.css({
-    position: 'absolute'
-  });
 };
 
 // trigger specified handler for event type
@@ -154,7 +150,7 @@ proto.getPosition = function() {
 // set settled position, apply padding
 proto.layoutPosition = function() {
   var layoutSize = this.layout.size;
-  var style = {};
+  var style = {position: 'absolute'};
   var isOriginLeft = this.layout._getOption('originLeft');
   var isOriginTop = this.layout._getOption('originTop');
 


### PR DESCRIPTION
When I used Masonry library i had a problem: on page with infinity scroll the slider stuck to bottom of page if I swipe it by mouse. It code fix problem.