### PR TITLE
Add error checking on parentNode

### DIFF
--- a/item.js
+++ b/item.js
@@ -443,7 +443,10 @@ proto.stagger = function( delay ) {
 
 // remove element from DOM
 proto.removeElem = function() {
-  this.element.parentNode.removeChild( this.element );
+  var parent = this.element.parentNode;
+  if ( parent ) {
+    parent.removeChild( this.element );
+  }
   // remove display: none
   this.css({ display: '' });
   this.emitEvent( 'remove', [ this ] );


### PR DESCRIPTION
Added error checking to block removing from parentNode if element was already removed

This is compiled into the packery code.  I was hitting errors where another library had already removed the element from parentNode.